### PR TITLE
Add rounded rectangle mask functionality

### DIFF
--- a/Sources/SwiftyCrop/Models/CropViewModel.swift
+++ b/Sources/SwiftyCrop/Models/CropViewModel.swift
@@ -37,7 +37,7 @@ class CropViewModel: ObservableObject {
         case .circle, .square:
             let diameter = min(maskRadius * 2, min(size.width, size.height))
             maskSize = CGSize(width: diameter, height: diameter)
-        case .rectangle:
+        case .rectangle, .roundedRectangle:
             let maxWidth = min(size.width, maskRadius * 2)
             let maxHeight = min(size.height, maskRadius * 2)
             if maxWidth / maxHeight > rectAspectRatio {

--- a/Sources/SwiftyCrop/Models/MaskShape.swift
+++ b/Sources/SwiftyCrop/Models/MaskShape.swift
@@ -1,3 +1,3 @@
 public enum MaskShape: CaseIterable {
-    case circle, square, rectangle
+    case circle, square, rectangle, roundedRectangle
 }

--- a/Sources/SwiftyCrop/View/CropView.swift
+++ b/Sources/SwiftyCrop/View/CropView.swift
@@ -257,6 +257,8 @@ struct CropView: View {
           Circle()
         case .square, .rectangle:
           Rectangle()
+        case .roundedRectangle:
+            RoundedRectangle(cornerRadius: 21)
         }
       }
     }


### PR DESCRIPTION
## Summary
- Added ability to have rounded rectangle mask functionality to SwiftyCrop
- Updated Xcode project settings

## Test plan
- [ ] Test rounded rectangle mask functionality
- [ ] Verify existing crop functionality still works

🤖 Generated with [Claude Code](https://claude.ai/code)